### PR TITLE
Update name of ad_image transformation

### DIFF
--- a/transformations/ad_image_history.sql
+++ b/transformations/ad_image_history.sql
@@ -1,7 +1,7 @@
 -- adimages_history
 -- SCD Type 2 Table for Facebook Ads Ad Images
 {% assign target_dataset = vars.target_dataset_id %}
-{% assign target_table_id = 'adimages_history' %}
+{% assign target_table_id = 'ad_image_history' %}
 
 {% assign source_dataset = vars.source_dataset_id %}
 {% assign source_table_id = 'adimages' %}


### PR DESCRIPTION
## Description
The name adimages_history didn't follow our convention for naming of SCD Type 2 History table. The subject should be singular i.e., ad_image_history.sql